### PR TITLE
fix: rename and make property optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.17.2] - 2024-10-20
+
+### Fixed
+
+- Change FileItemInterface (make date optional)
+
 ## [0.17.0] - 2024-10-17
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@spacefill/integration-framework",
   "type": "module",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/spacefill/integration-framework"

--- a/src/task/LoadFileTaskInterfaces.ts
+++ b/src/task/LoadFileTaskInterfaces.ts
@@ -1,6 +1,6 @@
 export interface FileItemInterface {
   file: string;
-  modifiedDate: Date | undefined;
+  modifiedDate?: Date;
 }
 
 export interface LoadFileTaskInterface<T> {

--- a/src/transfer/FtpClient.ts
+++ b/src/transfer/FtpClient.ts
@@ -84,7 +84,7 @@ export class FtpClient implements TransferInterface {
     const files = await this.client.list(remotePath);
     return files.map((file) => ({
       name: file.name as unknown as string,
-      date: file.modifiedAt,
+      modifiedDate: file.modifiedAt,
     }));
   }
 

--- a/src/transfer/LocalClient.ts
+++ b/src/transfer/LocalClient.ts
@@ -41,7 +41,7 @@ export class LocalClient implements TransferInterface {
       const stats = fs.statSync(path.join(remotePath, file));
       return {
         name: file,
-        date: stats.mtime,
+        modifiedDate: stats.mtime,
       };
     });
   }

--- a/src/transfer/SftpClient.ts
+++ b/src/transfer/SftpClient.ts
@@ -69,7 +69,7 @@ export class SftpClient implements TransferInterface {
     const fileds = await this.client.list(remotePath);
     return fileds.map((file) => ({
       name: file.name as unknown as string,
-      date: file.modifyTime ? new Date(file.modifyTime) : undefined,
+      modifiedDate: file.modifyTime ? new Date(file.modifyTime) : undefined,
     }));
   }
 

--- a/src/transfer/Transfer.ts
+++ b/src/transfer/Transfer.ts
@@ -141,8 +141,8 @@ class Transfer implements TransferInterface {
         .filter(({ name }) => {
           return name.match(new RegExp(fileNamePattern));
         })
-        .map(({ name, date }) => {
-          return { name: path.join(remotePath, name), date };
+        .map(({ name, modifiedDate }) => {
+          return { name: path.join(remotePath, name), modifiedDate };
         });
 
       Console.debug(`Files list: ${result}`);

--- a/src/transfer/TransferInterfaces.ts
+++ b/src/transfer/TransferInterfaces.ts
@@ -13,7 +13,7 @@ interface TransferInterface {
 
 interface FileMetadata {
   name: string;
-  date: Date | undefined;
+  modifiedDate?: Date;
 }
 
 interface TransferConfiguration {


### PR DESCRIPTION
J'ai rendu la date optionnelle pour ne pas bloquer l'autre méthode qui renvoie aussi des FileItemInterface et j'ai changé le nom de la propriété pour être cohérent avec le Filemetadata